### PR TITLE
EOSPlus+Steam friend-join: mainline generic LAN-emu fixes

### DIFF
--- a/src/connect.c
+++ b/src/connect.c
@@ -915,13 +915,22 @@ EOS_DECLARE_FUNC(EOS_ProductUserId) EOS_Connect_GetExternalAccountMapping(
     // local user's Connect id and each peer's puid (from its LAN beacon).
     ConnectState* state = (ConnectState*)Handle;
     if (state && state->platform) {
-        EOS_ProductUserId puid = social_bridge_resolve_puid(state->platform, Options->TargetExternalUserId);
+        EOS_ProductUserId puid;
+        if (Options->AccountIdType == EOS_EAT_STEAM) {
+            // Steam-friend-driven join UIs map a Steam friend's id -> PUID here.
+            puid = social_bridge_resolve_puid_by_steam(state->platform, Options->TargetExternalUserId);
+        } else {
+            // Default/Epic path: target is an EpicAccountId string.
+            puid = social_bridge_resolve_puid(state->platform, Options->TargetExternalUserId);
+        }
         if (puid) {
-            EOS_LOG_INFO(">>> GetExternalAccountMapping -> resolved real ProductUserId");
+            EOS_LOG_INFO(">>> GetExternalAccountMapping -> resolved real ProductUserId (type=%d)",
+                         (int)Options->AccountIdType);
             return puid;
         }
     }
-    EOS_LOG_WARN(">>> GetExternalAccountMapping -> no mapping found for '%s'", Options->TargetExternalUserId);
+    EOS_LOG_WARN(">>> GetExternalAccountMapping -> no mapping found for '%s' (type=%d)",
+                 Options->TargetExternalUserId, (int)Options->AccountIdType);
     return NULL;
 }
 

--- a/src/internal/lan_discovery.h
+++ b/src/internal/lan_discovery.h
@@ -43,6 +43,13 @@ void discovery_poll(DiscoveryService* ds);
 Session* discovery_get_sessions(DiscoveryService* ds, int* out_count);
 
 /**
+ * Find a single discovered session by its session_id in the live cache, or NULL.
+ * Used to re-pull the freshest advertised attributes for a session the game is
+ * about to read/join, instead of a stale search-time snapshot.
+ */
+const Session* discovery_find_cached_session(DiscoveryService* ds, const char* session_id);
+
+/**
  * Clear all discovered sessions.
  */
 void discovery_clear(DiscoveryService* ds);

--- a/src/internal/platform_internal.h
+++ b/src/internal/platform_internal.h
@@ -21,6 +21,15 @@ typedef struct PlatformState {
     EOS_ENetworkStatus network_status;
     EOS_EApplicationStatus app_status;
 
+    // Product identity the game passed to EOS_Platform_Create, deep-copied (the
+    // Options strings are caller-owned and may dangle after create returns). Used
+    // to report a peer's presence with the REAL product — a LAN clone runs the same
+    // product, and games filter friends whose presence ProductId/Version != their
+    // own, so a hardcoded/wrong ProductId hides the host from the Join Game list.
+    char product_id[64];
+    char product_name[128];
+    char product_version[64];
+
     // Subsystem handles
     ConnectState* connect;
     SessionsState* sessions;

--- a/src/internal/sessions_internal.h
+++ b/src/internal/sessions_internal.h
@@ -156,7 +156,13 @@ typedef struct {
 // Session details handle
 typedef struct {
     uint32_t magic;  // 0x53445448 = "SDTH"
-    Session session;  // Copy of session data
+    Session session;  // Copy of session data (snapshot at creation time)
+    // Back-pointer to the owning sessions state so CopyInfo can re-pull the
+    // LATEST advertised session from the live discovery cache by session_id.
+    // Without this the handle is frozen at search/Find time; a joiner that
+    // searched while the host's session was still incomplete (e.g. host mid-load,
+    // 17 of 27 attrs) would otherwise read stale attributes and fail to migrate.
+    struct SessionsState* sessions_state;
 } SessionDetailsHandle;
 
 // Active session handle

--- a/src/internal/sessions_internal.h
+++ b/src/internal/sessions_internal.h
@@ -224,6 +224,15 @@ void generate_session_id(char* buffer, size_t buffer_size);
 const char* social_bridge_local_join_info(void);
 const PresenceRecord* social_bridge_local_records(int* out_count);
 
+// Auto-derive the local user's published presence from a presence-enabled lobby
+// (real EOS behavior). Called by lobby.c on create/update/join of a
+// bPresenceEnabled lobby; no-op if the game sets presence itself. Lets games that
+// never touch the Presence interface (e.g. StarRupture) still expose a joinable
+// presence record + join-info to friends' CopyPresence/GetJoinInfo.
+void social_bridge_set_presence_from_lobby(const char* join_info,
+                                           const PresenceRecord* records, int record_count);
+void social_bridge_clear_lobby_presence(void);
+
 // Resolve an external (Epic) account id string -> the matching ProductUserId:
 // the local user's own Connect id, or a discovered peer's (carried in its LAN
 // beacon as epic_id+puid). Used by EOS_Connect_GetExternalAccountMapping so the

--- a/src/internal/sessions_internal.h
+++ b/src/internal/sessions_internal.h
@@ -27,7 +27,14 @@ typedef struct DiscoveryService DiscoveryService;
 // LAN announce so the joiner's EOS_Presence_GetJoinInfo/CopyPresence return
 // exactly what the host published (games parse their own join-info format).
 #define PRESENCE_JOININFO_LEN 256   // EOS_PRESENCE_DATA_MAX_VALUE_LENGTH + 1
-#define MAX_PRESENCE_RECORDS 8
+// 24 (was 8): a presence-enabled lobby host advertises ~14 attributes
+// (CUSTOMJOININFO, MapName, conn counts, GameMode, SESSIONTEMPLATENAME, OSSv1,
+// ALLOWEDPLATFORM, BUILDCL, MATCHTIMEOUT, BuildUniqueId, ...). UE copies every
+// presence record verbatim into FOnlineUserPresence.Status.Properties, and the
+// game's own join code reads those keys to decide joinable — so truncating to 8
+// dropped keys the game may gate on (platform/build/template). Beacon buffer is
+// 64KB; 24 records (~7.7KB) fits, and prec_count is a uint8_t (<=255).
+#define MAX_PRESENCE_RECORDS 24
 #define PRESENCE_KEY_LEN 65         // EOS_PRESENCE_DATA_MAX_KEY_LENGTH + 1
 #define PRESENCE_VALUE_LEN 256      // EOS_PRESENCE_DATA_MAX_VALUE_LENGTH + 1
 

--- a/src/internal/sessions_internal.h
+++ b/src/internal/sessions_internal.h
@@ -250,6 +250,12 @@ EOS_ProductUserId social_bridge_resolve_puid(PlatformState* platform, const char
 // Steam-friend-driven join UIs can attribute a discovered lobby to a friend.
 EOS_ProductUserId social_bridge_resolve_puid_by_steam(PlatformState* platform, const char* steam_id);
 
+// Resolve a STEAM external id -> peer's EpicAccountId STRING (last-refreshed peer
+// table; no PlatformState). Lets EOS_EpicAccountId_FromString map a Steam external
+// id to the peer's real epic handle so UE's epic-keyed external-id-mapping registry
+// (FUserManagerEOS) round-trips and the Steam friend gets enqueued for join search.
+const char* social_bridge_resolve_epic_by_steam(const char* steam_id);
+
 // Reverse of the above: given a ProductUserId string, return the EpicAccountId
 // string it belongs to (the local user, or a discovered peer carried in its LAN
 // beacon), or NULL if unknown. Used by EOS_Connect_GetProductUserIdMapping so the

--- a/src/internal/sessions_internal.h
+++ b/src/internal/sessions_internal.h
@@ -46,6 +46,7 @@ typedef struct {
 typedef struct UserBeacon {
     char epic_id[33];                       // 32-hex EpicAccountId string
     char puid[33];                          // 32-hex ProductUserId string
+    char steam_id[24];                      // decimal Steam ID (EOSLAN_STEAM_ID), "" if unset
     char display_name[PEER_DISPLAY_NAME_LEN];
     char join_info[PRESENCE_JOININFO_LEN];
     PresenceRecord records[MAX_PRESENCE_RECORDS];
@@ -228,6 +229,10 @@ const PresenceRecord* social_bridge_local_records(int* out_count);
 // beacon as epic_id+puid). Used by EOS_Connect_GetExternalAccountMapping so the
 // game can resolve a joinable host's (and its own) identity during an EOS join.
 EOS_ProductUserId social_bridge_resolve_puid(PlatformState* platform, const char* epic_id);
+// Resolve a STEAM external account id -> ProductUserId (peer Steam ID relayed in
+// its LAN beacon). Used by EOS_Connect_GetExternalAccountMapping for type=STEAM so
+// Steam-friend-driven join UIs can attribute a discovered lobby to a friend.
+EOS_ProductUserId social_bridge_resolve_puid_by_steam(PlatformState* platform, const char* steam_id);
 
 // Reverse of the above: given a ProductUserId string, return the EpicAccountId
 // string it belongs to (the local user, or a discovered peer carried in its LAN

--- a/src/lan_discovery.c
+++ b/src/lan_discovery.c
@@ -665,6 +665,16 @@ Session* discovery_get_sessions(DiscoveryService* ds, int* out_count) {
     return &ds->cache[0].session;
 }
 
+const Session* discovery_find_cached_session(DiscoveryService* ds, const char* session_id) {
+    if (!ds || !session_id) return NULL;
+    for (int i = 0; i < ds->cache_count; i++) {
+        if (strcmp(ds->cache[i].session.session_id, session_id) == 0) {
+            return &ds->cache[i].session;
+        }
+    }
+    return NULL;
+}
+
 void discovery_clear_sessions(DiscoveryService* ds) {
     if (!ds) return;
     ds->cache_count = 0;

--- a/src/lan_discovery.c
+++ b/src/lan_discovery.c
@@ -318,6 +318,8 @@ void discovery_broadcast_user(DiscoveryService* ds, const UserBeacon* user) {
     strncpy((char*)(buf + offset), user->epic_id, 32); offset += 33;
     memset(buf + offset, 0, 33);
     strncpy((char*)(buf + offset), user->puid, 32); offset += 33;
+    memset(buf + offset, 0, 24);                                  // steam_id (decimal, "" if unset)
+    strncpy((char*)(buf + offset), user->steam_id, 23); offset += 24;
     memset(buf + offset, 0, PEER_DISPLAY_NAME_LEN);
     strncpy((char*)(buf + offset), user->display_name, PEER_DISPLAY_NAME_LEN - 1); offset += PEER_DISPLAY_NAME_LEN;
     memset(buf + offset, 0, PRESENCE_JOININFO_LEN);
@@ -354,9 +356,10 @@ static bool parse_user_beacon(const uint8_t* buf, int len, UserBeacon* user) {
     int offset = 0;
     memset(user, 0, sizeof(*user));
 
-    if (offset + 33 + 33 + PEER_DISPLAY_NAME_LEN + PRESENCE_JOININFO_LEN + 1 > len) return false;
+    if (offset + 33 + 33 + 24 + PEER_DISPLAY_NAME_LEN + PRESENCE_JOININFO_LEN + 1 > len) return false;
     memcpy(user->epic_id, buf + offset, 32); user->epic_id[32] = '\0'; offset += 33;
     memcpy(user->puid, buf + offset, 32); user->puid[32] = '\0'; offset += 33;
+    memcpy(user->steam_id, buf + offset, 23); user->steam_id[23] = '\0'; offset += 24;
     memcpy(user->display_name, buf + offset, PEER_DISPLAY_NAME_LEN);
     user->display_name[PEER_DISPLAY_NAME_LEN - 1] = '\0'; offset += PEER_DISPLAY_NAME_LEN;
     memcpy(user->join_info, buf + offset, PRESENCE_JOININFO_LEN);

--- a/src/lobby.c
+++ b/src/lobby.c
@@ -598,6 +598,63 @@ EOS_DECLARE_FUNC(EOS_HLobby) EOS_Platform_GetLobbyInterface(EOS_HPlatform Handle
  * Core EOS_Lobby_* functions
  * ===========================================================================*/
 
+/* Stringify a lobby attribute into a presence data record (presence records are
+ * always key/value strings, lobby attributes are typed). */
+static void lobby_attr_to_record(const LobbyAttribute* la, PresenceRecord* out) {
+    char val[PRESENCE_VALUE_LEN];
+    switch (la->type) {
+        case EOS_AT_BOOLEAN: snprintf(val, sizeof(val), "%s", la->value.as_bool ? "true" : "false"); break;
+        case EOS_AT_INT64:   snprintf(val, sizeof(val), "%lld", (long long)la->value.as_int64); break;
+        case EOS_AT_DOUBLE:  snprintf(val, sizeof(val), "%g", la->value.as_double); break;
+        case EOS_AT_STRING:
+        default:             snprintf(val, sizeof(val), "%s", la->value.as_string); break;
+    }
+    strncpy(out->key, la->key, PRESENCE_KEY_LEN - 1);   out->key[PRESENCE_KEY_LEN - 1] = '\0';
+    strncpy(out->value, val, PRESENCE_VALUE_LEN - 1);   out->value[PRESENCE_VALUE_LEN - 1] = '\0';
+}
+
+/* Mirror a presence-enabled lobby into the local user's published EOS presence so
+ * a friend's EOS_Presence_CopyPresence/GetJoinInfo return a joinable record. Real
+ * EOS does this automatically for bPresenceEnabled lobbies; games like StarRupture
+ * rely on it and never call the Presence interface themselves (their host only
+ * creates a presence-enabled lobby with a CUSTOMJOININFO attribute). We expose the
+ * lobby id as the join-info (the joiner can EOS_Lobby_JoinLobbyById it) and surface
+ * the lobby attributes as presence data records. Records are capped at
+ * MAX_PRESENCE_RECORDS, so the join-critical keys are emitted first regardless of
+ * attribute order. social_bridge no-ops this if the game manages its own presence. */
+static void lobby_sync_local_presence(const Lobby* l) {
+    if (!l || !l->presence_enabled) return;
+
+    static const char* const priority[] = {
+        "CUSTOMJOININFO", "MapName", "NumPublicConnections", "NumPrivateConnections",
+    };
+    const int priority_count = (int)(sizeof(priority) / sizeof(priority[0]));
+
+    PresenceRecord recs[MAX_PRESENCE_RECORDS];
+    int n = 0;
+    bool used[MAX_LOBBY_ATTRIBUTES];
+    memset(used, 0, sizeof(used));
+
+    /* Pass 1: priority keys, in priority order. */
+    for (int k = 0; k < priority_count && n < MAX_PRESENCE_RECORDS; k++) {
+        for (int i = 0; i < l->attribute_count; i++) {
+            if (used[i]) continue;
+            if (strncmp(l->attributes[i].key, priority[k], MAX_LOBBY_ATTRIBUTE_KEY_LEN) != 0) continue;
+            lobby_attr_to_record(&l->attributes[i], &recs[n++]);
+            used[i] = true;
+            break;
+        }
+    }
+    /* Pass 2: remaining attributes, in order, until the cap. */
+    for (int i = 0; i < l->attribute_count && n < MAX_PRESENCE_RECORDS; i++) {
+        if (used[i]) continue;
+        lobby_attr_to_record(&l->attributes[i], &recs[n++]);
+        used[i] = true;
+    }
+
+    social_bridge_set_presence_from_lobby(l->lobby_id, recs, n);
+}
+
 EOS_DECLARE_FUNC(void) EOS_Lobby_CreateLobby(
     EOS_HLobby Handle,
     const EOS_Lobby_CreateLobbyOptions* Options,
@@ -691,6 +748,10 @@ EOS_DECLARE_FUNC(void) EOS_Lobby_CreateLobby(
     /* Start announcing immediately. */
     lobby_request_announce(state);
 
+    /* A presence-enabled lobby ties to the local user's presence (real EOS).
+     * Attributes are added later via UpdateLobby; this seeds the join-info now. */
+    lobby_sync_local_presence(l);
+
     info.ResultCode = EOS_Success;
     info.LobbyId = stable_lobby_id(l->lobby_id);
 
@@ -741,6 +802,10 @@ EOS_DECLARE_FUNC(void) EOS_Lobby_DestroyLobby(
         info.ResultCode = EOS_Lobby_NotOwner;
         goto queue_callback;
     }
+
+    /* This lobby drove our presence join-info; drop it so friends stop seeing us
+     * as joinable. */
+    if (l->presence_enabled) social_bridge_clear_lobby_presence();
 
     index = (int)(l - state->local_lobbies);
     if (index >= 0 && index < state->local_lobby_count) {
@@ -807,6 +872,10 @@ static EOS_EResult lobby_join_common(LobbyState* state, const Lobby* snapshot,
 
     state->local_lobby_count++;
     lobby_request_announce(state);
+
+    /* A joiner of a presence-enabled lobby also reflects it in its own presence
+     * (real EOS), so its friends can in turn join through it. */
+    lobby_sync_local_presence(l);
 
     lobby_fire_member_status(state, l->lobby_id, local_user, EOS_LMS_JOINED);
     return EOS_Success;
@@ -940,6 +1009,8 @@ EOS_DECLARE_FUNC(void) EOS_Lobby_LeaveLobby(
      * TargetUserId is the caller-owned LocalUserId, so neither dangles. */
     lobby_fire_member_status(state, Options->LobbyId, Options->LocalUserId, EOS_LMS_LEFT);
 
+    if (l->presence_enabled) social_bridge_clear_lobby_presence();
+
     index = (int)(l - state->local_lobbies);
     if (index >= 0 && index < state->local_lobby_count) {
         memmove(&state->local_lobbies[index],
@@ -1072,6 +1143,10 @@ EOS_DECLARE_FUNC(void) EOS_Lobby_UpdateLobby(
 
     info.ResultCode = EOS_Success;
     EOS_LOG_INFO("Lobby updated: %s", l->lobby_id);
+
+    /* Re-derive presence now that the lobby's attributes (CUSTOMJOININFO, MapName,
+     * conn counts) are committed, so friends' CopyPresence sees the join records. */
+    lobby_sync_local_presence(l);
 
     /* Notify listeners that the lobby (and possibly a member) changed. */
     lobby_fire_lobby_update(state, l->lobby_id);

--- a/src/lobby_search.c
+++ b/src/lobby_search.c
@@ -354,17 +354,20 @@ EOS_DECLARE_FUNC(void) EOS_LobbySearch_Find(
             }
         }
 
-        // Check target user ID filter (user must be a registered member)
+        // Check target user ID filter (user must be the owner or a registered member).
+        // Wire-discovered lobbies carry only the owner over the LAN broadcast — members[]
+        // is empty until the lobby is joined — so a search-by-user for the host (the common
+        // "join by presence / find friend's game" path, e.g. StarRupture's join menu) must
+        // match against the owner, not just the member roster, or it wrongly returns 0.
         if (search->target_user_id != NULL) {
-            bool user_found = false;
-            for (int j = 0; j < l->member_count; j++) {
+            bool user_found = (l->owner_id != NULL && l->owner_id == search->target_user_id);
+            for (int j = 0; !user_found && j < l->member_count; j++) {
                 if (l->members[j].valid && l->members[j].member_id == search->target_user_id) {
                     user_found = true;
-                    break;
                 }
             }
             if (!user_found) {
-                EOS_LOG_INFO("LobbySearch_Find:     REJECT target_user_id not found among %d members (members[] empty on wire-discovered lobbies)", l->member_count);
+                EOS_LOG_INFO("LobbySearch_Find:     REJECT target_user_id not owner and not among %d member(s)", l->member_count);
                 continue;
             }
         }

--- a/src/palworld_stubs.c
+++ b/src/palworld_stubs.c
@@ -42,10 +42,16 @@ EOS_DECLARE_FUNC(EOS_EpicAccountId) EOS_EpicAccountId_FromString(const char* Str
     EOS_LOG_INFO("EpicAccountId_FromString('%s')", String ? String : "NULL");
     extern AuthState g_auth_state;
 
-    // Garbage/short input: keep the old back-compat behavior (hand back the local
-    // user) so degenerate callers don't crash.
+    // A well-formed EpicAccountId is exactly EPIC_ACCOUNT_ID_LENGTH hex chars. Real
+    // EOS returns an INVALID id for anything else, and we MUST too: Steam+EOS games
+    // bridging external accounts call FromString on a *Steam ID* string (e.g.
+    // "76561198000000001", 17 chars). Handing back the LOCAL user there associates a
+    // remote host's puid with the joiner's epic, violating UE's one-puid<->one-epic
+    // registry invariant (FUniqueNetIdEOSRegistry asserts InEpicAccountId ==
+    // FoundEpicAccountId -> hard crash). NULL makes EpicAccountId_IsValid() return
+    // false, so the caller treats the id as absent (PUID-only) instead of mismatched.
     if (!String || strlen(String) != EPIC_ACCOUNT_ID_LENGTH) {
-        return g_auth_state.logged_in ? (EOS_EpicAccountId)&g_auth_state.account_id : NULL;
+        return NULL;
     }
 
     // The local user's own id -> the canonical local handle (stable pointer).

--- a/src/palworld_stubs.c
+++ b/src/palworld_stubs.c
@@ -9,6 +9,11 @@
 #include "internal/auth_internal.h"
 #include <string.h>
 
+// Implemented in social_bridge.c. Declared here (not via sessions_internal.h, which
+// pulls in session types that clash with this file's platform-stub definitions) so
+// EOS_EpicAccountId_FromString can map a Steam external id -> the peer's real epic.
+extern const char* social_bridge_resolve_epic_by_steam(const char* steam_id);
+
 // Suppress unused parameter warnings
 #define UNUSED(x) (void)(x)
 
@@ -51,6 +56,21 @@ EOS_DECLARE_FUNC(EOS_EpicAccountId) EOS_EpicAccountId_FromString(const char* Str
     // FoundEpicAccountId -> hard crash). NULL makes EpicAccountId_IsValid() return
     // false, so the caller treats the id as absent (PUID-only) instead of mismatched.
     if (!String || strlen(String) != EPIC_ACCOUNT_ID_LENGTH) {
+        // Not a 32-hex epic id. UE's FUserManagerEOS::GetExternalIdMapping treats
+        // EVERY external id as an epic id (FromString -> IsValid -> registry Find),
+        // so a Steam friend id ('765611...') would resolve to NULL and the friend is
+        // never enqueued for the friends "Join Game" search. Map a known Steam id to
+        // the peer's REAL epic id and intern THAT — so the epic-keyed registry
+        // round-trips (FindOrAdd on the steam query and Find on the read both land on
+        // the host's real epic handle). Returns the REMOTE peer's epic, never the
+        // local user's, so it does NOT reintroduce the one-puid<->one-epic crash.
+        if (String) {
+            const char* peer_epic = social_bridge_resolve_epic_by_steam(String);
+            if (peer_epic && strlen(peer_epic) == EPIC_ACCOUNT_ID_LENGTH) {
+                EOS_LOG_INFO("EpicAccountId_FromString: external id '%s' -> peer epic %s", String, peer_epic);
+                return EOS_EpicAccountId_FromString(peer_epic);  // recurse: interns the real epic
+            }
+        }
         return NULL;
     }
 

--- a/src/platform.c
+++ b/src/platform.c
@@ -14,6 +14,12 @@
 bool g_sdk_initialized = false;
 PlatformState* g_platforms[8] = {NULL};
 
+// ProductName/ProductVersion live on EOS_InitializeOptions (not Platform_Options);
+// captured here so EOS_Platform_Create can stamp them onto the platform for
+// presence reporting.
+static char g_product_name[128] = {0};
+static char g_product_version[64] = {0};
+
 EOS_DECLARE_FUNC(EOS_EResult) EOS_Initialize(const EOS_InitializeOptions* Options) {
     if (!Options || Options->ApiVersion != EOS_INITIALIZE_API_LATEST) {
         return EOS_InvalidParameters;
@@ -31,6 +37,8 @@ EOS_DECLARE_FUNC(EOS_EResult) EOS_Initialize(const EOS_InitializeOptions* Option
     log_init(LOG_LEVEL_TRACE, log_path);
 
     g_sdk_initialized = true;
+    if (Options->ProductName)    strncpy(g_product_name, Options->ProductName, sizeof(g_product_name) - 1);
+    if (Options->ProductVersion) strncpy(g_product_version, Options->ProductVersion, sizeof(g_product_version) - 1);
     EOS_LOG_INFO("EOS SDK Initialized: %s v%s",
                  Options->ProductName, Options->ProductVersion);
 
@@ -128,6 +136,13 @@ EOS_DECLARE_FUNC(EOS_HPlatform) EOS_Platform_Create(const EOS_Platform_Options* 
     platform->initialized = true;
     platform->network_status = EOS_NS_Online;
     platform->app_status = EOS_AS_Foreground;
+
+    // Deep-copy the product identity (Options strings are caller-owned). Reported
+    // back as a peer's presence product so the game doesn't treat the LAN host as a
+    // different game and filter it out of Join Game (calloc already zeroed these).
+    if (Options->ProductId) strncpy(platform->product_id, Options->ProductId, sizeof(platform->product_id) - 1);
+    strncpy(platform->product_name, g_product_name, sizeof(platform->product_name) - 1);
+    strncpy(platform->product_version, g_product_version, sizeof(platform->product_version) - 1);
 
     // Initialize LAN config with defaults
     platform->lan_config.discovery_port = 23456;

--- a/src/session_details.c
+++ b/src/session_details.c
@@ -1,6 +1,7 @@
 #include "eos/eos_sessions.h"
 #include "eos/eos_sessions_types.h"
 #include "internal/sessions_internal.h"
+#include "internal/lan_discovery.h"
 #include "internal/logging.h"
 #include <stdlib.h>
 #include <string.h>
@@ -87,6 +88,23 @@ EOS_DECLARE_FUNC(EOS_EResult) EOS_SessionDetails_CopyInfo(
 
     if (!OutSessionInfo) {
         return EOS_InvalidParameters;
+    }
+
+    // Refresh from the live discovery cache before handing the session to the
+    // game. The handle's copy was snapshotted at search/Find time; if the host's
+    // session has since gained attributes (e.g. the host finished loading and
+    // added the gameplay attrs needed to migrate), use the freshest advertised
+    // copy. This fixes a joiner that searched a hair too early reading a stale,
+    // incomplete (e.g. 17-of-27 attr) session and failing the backend join.
+    if (details->sessions_state && details->sessions_state->discovery) {
+        const Session* fresh = discovery_find_cached_session(
+            details->sessions_state->discovery, details->session.session_id);
+        if (fresh && fresh->attribute_count > details->session.attribute_count) {
+            EOS_LOG_INFO(">>> CopyInfo: refreshing session '%s' from live cache (attrs %d -> %d)",
+                         details->session.session_id, details->session.attribute_count,
+                         fresh->attribute_count);
+            details->session = *fresh;
+        }
     }
 
     EOS_SessionDetails_Info* info = session_to_info(&details->session);

--- a/src/session_search.c
+++ b/src/session_search.c
@@ -415,6 +415,7 @@ EOS_DECLARE_FUNC(EOS_EResult) EOS_SessionSearch_CopySearchResultByIndex(
 
     details->magic = 0x53445448;
     details->session = search->results[Options->SessionIndex];
+    details->sessions_state = search->sessions_state;  // for CopyInfo live refresh
 
     *OutSessionHandle = (EOS_HSessionDetails)details;
     return EOS_Success;

--- a/src/session_search.c
+++ b/src/session_search.c
@@ -325,18 +325,33 @@ EOS_DECLARE_FUNC(void) EOS_SessionSearch_Find(
             }
         }
 
-        // Check target user ID filter
+        // Check target user ID filter (session OWNER or a registered player).
+        // Wire-discovered sessions carry only the owner over the LAN broadcast
+        // (registered_players[] is empty until joined, and owner_id is a process-local
+        // pointer — only owner_id_string survives the wire). The friends "Join Game"
+        // browser does a per-friend Sessions search keyed on the friend's puid, so we
+        // MUST match the owner by string or it returns 0 even though the friend is
+        // hosting (this is what left StarRupture's friends browser empty).
         if (search->target_user_id != NULL) {
             bool user_found = false;
-            for (int j = 0; j < s->registered_player_count; j++) {
+            char tgt[64];
+            int32_t tlen = (int32_t)sizeof(tgt);
+            if (EOS_ProductUserId_ToString(search->target_user_id, tgt, &tlen) == EOS_Success &&
+                s->owner_id_string[0] != '\0' && strcmp(s->owner_id_string, tgt) == 0) {
+                user_found = true;
+            }
+            for (int j = 0; !user_found && j < s->registered_player_count; j++) {
                 if (s->registered_players[j] == search->target_user_id) {
                     user_found = true;
-                    break;
                 }
             }
             if (!user_found) {
+                EOS_LOG_INFO("SessionSearch_Find: REJECT '%s' target_user not owner/player",
+                             s->session_id);
                 continue;
             }
+            EOS_LOG_INFO("SessionSearch_Find: ACCEPT '%s' (owner match for target user)",
+                         s->session_id);
         }
 
         // Check parameter filters

--- a/src/sessions.c
+++ b/src/sessions.c
@@ -365,6 +365,10 @@ EOS_DECLARE_FUNC(void) EOS_Sessions_UpdateSession(
         info.SessionId = s->session_id;
 
         EOS_LOG_INFO("Session created: %s (ID: %s)", s->session_name, s->session_id);
+
+        // Push the new session to the LAN immediately instead of waiting for the
+        // next ~2s announce tick, so a joiner searching right now sees it.
+        if (state->discovery) discovery_broadcast_session(state->discovery, s);
     } else {
         // Updating existing session
         Session* existing = find_local_session_by_name(state, mod->session.session_name);
@@ -380,6 +384,13 @@ EOS_DECLARE_FUNC(void) EOS_Sessions_UpdateSession(
         info.ResultCode = EOS_Success;
         info.SessionName = existing->session_name;
         info.SessionId = existing->session_id;
+
+        // Broadcast the UPDATED session immediately. This is the core fix for the
+        // splitux join race: when the host finishes loading and adds its gameplay
+        // attributes (17 -> 27), the joiner's discovery cache is refreshed within
+        // milliseconds instead of up to ~2s later, so a joiner reading the session
+        // right then gets the complete copy and can migrate.
+        if (state->discovery) discovery_broadcast_session(state->discovery, existing);
     }
 
 queue_callback:
@@ -933,6 +944,7 @@ static EOS_EResult copy_details_by_session_id(SessionsState* state, const char* 
     }
     details->magic = 0x53445448;
     details->session = *found;
+    details->sessions_state = state;  // for CopyInfo live refresh
     *OutSessionHandle = (EOS_HSessionDetails)details;
     return EOS_Success;
 }
@@ -983,6 +995,7 @@ EOS_DECLARE_FUNC(EOS_EResult) EOS_Sessions_CopySessionHandleForPresence(
             if (!details) return EOS_LimitExceeded;
             details->magic = 0x53445448;
             details->session = *s;
+            details->sessions_state = state;  // for CopyInfo live refresh
             *OutSessionHandle = (EOS_HSessionDetails)details;
             EOS_LOG_INFO(">>> EOS_Sessions_CopySessionHandleForPresence -> '%s'", s->session_name);
             return EOS_Success;

--- a/src/social_bridge.c
+++ b/src/social_bridge.c
@@ -81,6 +81,14 @@ typedef struct {
 
 static LocalPresence g_local_presence;
 
+// Set once the game publishes presence through the Presence interface directly
+// (SetJoinInfo/SetData -> SetPresence, e.g. Satisfactory). When set, we leave the
+// game's presence alone and do NOT auto-derive it from a presence-enabled lobby —
+// the game knows best. Games that never touch the Presence interface and rely on a
+// bPresenceEnabled lobby instead (e.g. StarRupture) leave this clear, so the lobby
+// auto-derive below populates their presence.
+static int g_game_set_presence = 0;
+
 // Accessors for sessions.c (stamps local presence onto the LAN announce).
 const char* social_bridge_local_join_info(void) {
     return g_local_presence.join_info;
@@ -248,6 +256,7 @@ EOS_DECLARE_FUNC(void) EOS_Presence_SetPresence(EOS_HPresence Handle, const EOS_
         for (int i = 0; i < mod->record_count; i++) {
             local_presence_set(mod->records[i].key, mod->records[i].value);
         }
+        g_game_set_presence = 1;  // game owns its presence; suppress lobby auto-derive
         info.ResultCode = EOS_Success;
         EOS_LOG_INFO(">>> EOS_Presence_SetPresence merged: join_info='%s', %d record(s) total",
                      g_local_presence.join_info, g_local_presence.record_count);
@@ -266,6 +275,43 @@ EOS_DECLARE_FUNC(void) EOS_PresenceModification_Release(EOS_HPresenceModificatio
         mod->magic = 0;
         free(mod);
     }
+}
+
+// Auto-derive the local user's published presence from a presence-enabled lobby.
+// Real EOS ties a bPresenceEnabled lobby to the user's presence so a friend's
+// EOS_Presence_CopyPresence / GetJoinInfo return a joinable record WITHOUT the
+// host ever calling the Presence interface. Games like StarRupture depend on this
+// (their host never touches EOS_Presence_*; it just creates a presence-enabled
+// lobby with a CUSTOMJOININFO attribute). Without it the host's user beacon
+// carries empty presence -> the joiner's CopyPresence returns 0 records -> the
+// friends "Join Game" browser shows "No sessions available".
+// Called by lobby.c on create/update/join of a presence-enabled lobby. No-op if
+// the game manages presence itself (g_game_set_presence) so we never clobber a
+// game that uses the Presence interface directly (e.g. Satisfactory).
+void social_bridge_set_presence_from_lobby(const char* join_info,
+                                           const PresenceRecord* records, int record_count) {
+    if (g_game_set_presence) return;
+    if (join_info) {
+        strncpy(g_local_presence.join_info, join_info, sizeof(g_local_presence.join_info) - 1);
+        g_local_presence.join_info[sizeof(g_local_presence.join_info) - 1] = '\0';
+    }
+    int n = record_count;
+    if (n < 0) n = 0;
+    if (n > MAX_PRESENCE_RECORDS) n = MAX_PRESENCE_RECORDS;
+    for (int i = 0; i < n; i++) g_local_presence.records[i] = records[i];
+    g_local_presence.record_count = n;
+    EOS_LOG_INFO(">>> social_bridge: presence auto-derived from presence-enabled lobby: join_info='%s', %d record(s)",
+                 g_local_presence.join_info, g_local_presence.record_count);
+}
+
+// Clear lobby-derived presence when the local user leaves/destroys its
+// presence-enabled lobby. No-op if the game owns its presence.
+void social_bridge_clear_lobby_presence(void) {
+    if (g_game_set_presence) return;
+    if (g_local_presence.join_info[0] == '\0' && g_local_presence.record_count == 0) return;
+    g_local_presence.join_info[0] = '\0';
+    g_local_presence.record_count = 0;
+    EOS_LOG_INFO(">>> social_bridge: cleared lobby-derived presence");
 }
 
 static PeerFriend g_peers[MAX_DISCOVERED_SESSIONS];

--- a/src/social_bridge.c
+++ b/src/social_bridge.c
@@ -41,6 +41,7 @@
 typedef struct {
     EOS_EpicAccountIdDetails epic;          // peer's EpicAccountId (real from beacon, else synthetic = puid)
     char puid[OWNER_ID_STRING_LEN];         // peer's ProductUserId string (dedupe key across sources)
+    char steam_id[24];                      // peer's Steam ID (from beacon); "" if the peer had none
     char session_id[SESSION_ID_LEN + 1];    // the peer's session id (join target; may be empty)
     char host_address[HOST_ADDRESS_LEN];    // "IP:port"
     char join_info[PRESENCE_JOININFO_LEN];  // host's REAL SetJoinInfo string (from announce/beacon)
@@ -270,6 +271,20 @@ EOS_DECLARE_FUNC(void) EOS_PresenceModification_Release(EOS_HPresenceModificatio
 static PeerFriend g_peers[MAX_DISCOVERED_SESSIONS];
 static int g_peer_count = 0;
 
+// Local user's Steam ID — EOSLAN_STEAM_ID, set per-instance by the bench from the
+// goldberg account_steamid. Lets Steam+EOS games map a Steam friend -> PUID. NULL
+// when unset (non-Steam games are unaffected). Cached: env is fixed for the process.
+static const char* local_steam_id_string(void) {
+    static const char* cached = NULL;
+    static int resolved = 0;
+    if (!resolved) {
+        const char* s = getenv("EOSLAN_STEAM_ID");
+        cached = (s && s[0]) ? s : NULL;
+        resolved = 1;
+    }
+    return cached;
+}
+
 // Local user's product id string (to exclude our own discovered session).
 static const char* local_product_id_string(PlatformState* p) {
     if (!p || !p->connect) return NULL;
@@ -321,6 +336,8 @@ static void refresh_peers(PlatformState* p) {
             if (!pf) break;
             strncpy(pf->puid, ub->puid, sizeof(pf->puid) - 1);
             pf->puid[sizeof(pf->puid) - 1] = '\0';
+            strncpy(pf->steam_id, ub->steam_id, sizeof(pf->steam_id) - 1);
+            pf->steam_id[sizeof(pf->steam_id) - 1] = '\0';
             strncpy(pf->display_name, ub->display_name, sizeof(pf->display_name) - 1);
             pf->display_name[sizeof(pf->display_name) - 1] = '\0';
             strncpy(pf->join_info, ub->join_info, sizeof(pf->join_info) - 1);
@@ -414,6 +431,35 @@ EOS_ProductUserId social_bridge_resolve_puid(PlatformState* p, const char* epic_
     return NULL;
 }
 
+// Map a STEAM external account id string -> the matching ProductUserId. Steam+EOS
+// games (e.g. StarRupture) list Steam *friends* and resolve each friend's Steam ID
+// -> PUID (EOS_Connect_GetExternalAccountMapping, type=STEAM) to attribute a found
+// lobby to a friend; without this the friends-browser shows "no sessions available"
+// even though the lobby search returned the host. The Steam ID is relayed in the
+// peer's LAN beacon (EOSLAN_STEAM_ID, set per-instance by the bench).
+EOS_ProductUserId social_bridge_resolve_puid_by_steam(PlatformState* p, const char* steam_id) {
+    if (!p || !steam_id || !steam_id[0]) return NULL;
+    // Local user (the game resolving its own Steam identity).
+    const char* self_steam = local_steam_id_string();
+    if (self_steam && strcmp(steam_id, self_steam) == 0) {
+        const char* puid = local_product_id_string(p);
+        if (puid) {
+            return EOS_ProductUserId_FromString(puid);
+        }
+    }
+    // Discovered peer (the host) — Steam id relayed in its beacon.
+    refresh_peers(p);
+    for (int i = 0; i < g_peer_count; i++) {
+        if (g_peers[i].valid &&
+            g_peers[i].steam_id[0] != '\0' &&
+            strcmp(g_peers[i].steam_id, steam_id) == 0 &&
+            g_peers[i].puid[0] != '\0') {
+            return EOS_ProductUserId_FromString(g_peers[i].puid);
+        }
+    }
+    return NULL;
+}
+
 // Reverse mapping: ProductUserId string -> EpicAccountId string. The game calls
 // EOS_Connect_GetProductUserIdMapping on a session OWNER's puid to rebuild that
 // user's Epic identity during a join; without this it can't form the host user
@@ -497,6 +543,8 @@ static void broadcast_own_beacon(PlatformState* p) {
     strncpy(ub.epic_id, g_auth_state.account_id.id_string, 32);
     const char* puid = local_product_id_string(p);
     if (puid) strncpy(ub.puid, puid, 32);
+    const char* steam_id = local_steam_id_string();
+    if (steam_id) strncpy(ub.steam_id, steam_id, sizeof(ub.steam_id) - 1);
     strncpy(ub.display_name, g_auth_state.display_name, sizeof(ub.display_name) - 1);
     strncpy(ub.join_info, g_local_presence.join_info, sizeof(ub.join_info) - 1);
     memcpy(ub.records, g_local_presence.records, sizeof(ub.records));

--- a/src/social_bridge.c
+++ b/src/social_bridge.c
@@ -530,6 +530,28 @@ const char* social_bridge_resolve_epic_by_puid(PlatformState* p, const char* pui
     return NULL;
 }
 
+// Resolve a STEAM external id -> the matching peer's EpicAccountId STRING (or NULL).
+// No PlatformState needed (uses the last-refreshed g_peers table) so
+// EOS_EpicAccountId_FromString can be made to map a Steam external id to the peer's
+// REAL epic handle. WHY: UE's FUserManagerEOS::GetExternalIdMapping treats EVERY
+// external id as an epic id (FromString -> IsValid -> registry Find); a Steam friend
+// id would FromString to NULL, so the friend is never resolved/enqueued for the
+// friends "Join Game" search. Mapping the steam id to the peer's real epic (NOT the
+// local user) lets the epic-keyed registry round-trip without violating the
+// one-puid<->one-epic invariant (the regression that returning the LOCAL handle
+// caused — see palworld_stubs EpicAccountId_FromString).
+const char* social_bridge_resolve_epic_by_steam(const char* steam_id) {
+    if (!steam_id || !steam_id[0]) return NULL;
+    for (int i = 0; i < g_peer_count; i++) {
+        if (g_peers[i].valid && g_peers[i].steam_id[0] &&
+            strcmp(g_peers[i].steam_id, steam_id) == 0 &&
+            g_peers[i].epic.id_string[0]) {
+            return g_peers[i].epic.id_string;
+        }
+    }
+    return NULL;
+}
+
 // ===================== Push notifications =====================
 // Games (e.g. Satisfactory) query the friends list ONCE when the Join menu
 // opens and cache it; re-opening doesn't re-query. So returning peers on demand

--- a/src/social_bridge.c
+++ b/src/social_bridge.c
@@ -633,7 +633,18 @@ void social_bridge_tick(PlatformState* p) {
         // actually has a joinable session; the single fetch then runs against
         // complete data (session + presence + display name) in a clean
         // post-login window, succeeds, and the host resolves as an online user.
-        if (is_new && pf->session_id[0] == '\0') continue;
+        //
+        // "Joinable" can be a discovered EOS session (session_id) OR a
+        // presence-enabled lobby, whose join data arrives as presence records +
+        // join-info on the host's user beacon (no session_id — the lobby is not a
+        // session). EOSPlus+Steam titles like StarRupture are purely the latter:
+        // their friends "Join Game" reads the host's presence, and the game does
+        // its one-shot fetch off the OnPresenceChanged notification we fire here.
+        // Gate on record_count (the lobby presence is fully populated once its
+        // attributes have propagated) so the fetch still runs against complete
+        // data; without this the hold never releases for lobby hosts and the
+        // browser shows "No sessions available" forever.
+        if (is_new && pf->session_id[0] == '\0' && pf->record_count == 0) continue;
 
         uint32_t fp = presence_fingerprint(pf);
         if (!is_new && np->presence_fp == fp) continue;  // nothing changed

--- a/src/social_bridge.c
+++ b/src/social_bridge.c
@@ -782,7 +782,7 @@ EOS_DECLARE_FUNC(EOS_Bool) EOS_Presence_HasPresence(EOS_HPresence Handle, const 
 }
 
 EOS_DECLARE_FUNC(EOS_EResult) EOS_Presence_CopyPresence(EOS_HPresence Handle, const EOS_Presence_CopyPresenceOptions* Options, EOS_Presence_Info** OutPresence) {
-    (void)Handle;
+    PlatformState* plat = (PlatformState*)Handle;
     if (!OutPresence) return EOS_InvalidParameters;
     *OutPresence = NULL;
     EOS_EpicAccountId target = Options ? Options->TargetUserId : NULL;
@@ -804,11 +804,15 @@ EOS_DECLARE_FUNC(EOS_EResult) EOS_Presence_CopyPresence(EOS_HPresence Handle, co
     info->ApiVersion = EOS_PRESENCE_INFO_API_LATEST;
     info->Status = EOS_PS_Online;
     info->UserId = target;
-    info->ProductId = "Satisfactory";
-    info->ProductVersion = "1.0";
+    // Report the peer with OUR product identity — a LAN clone runs the same game,
+    // and the game filters friends whose presence ProductId/Version differs from
+    // its own (a hardcoded "Satisfactory" hid every other game's host). Falls back
+    // to a neutral string if the platform didn't carry product info.
+    info->ProductId = (plat && plat->product_id[0]) ? plat->product_id : "EOSLAN";
+    info->ProductVersion = (plat && plat->product_version[0]) ? plat->product_version : "1.0";
     info->Platform = "EOSLAN";
-    info->RichText = "Hosting a game";
-    info->ProductName = "Satisfactory";
+    info->RichText = "In Game";
+    info->ProductName = (plat && plat->product_name[0]) ? plat->product_name : "EOSLAN";
     info->IntegratedPlatform = "";
     // Relay the host's REAL presence data records (from the LAN announce).
     int n = (pf->record_count > MAX_PRESENCE_RECORDS) ? MAX_PRESENCE_RECORDS : pf->record_count;
@@ -822,7 +826,11 @@ EOS_DECLARE_FUNC(EOS_EResult) EOS_Presence_CopyPresence(EOS_HPresence Handle, co
     info->RecordsCount = n;
     info->Records = (n > 0) ? blk->recs : NULL;
     *OutPresence = info;
-    EOS_LOG_INFO(">>> EOS_Presence_CopyPresence: Online presence for peer, %d record(s)", n);
+    EOS_LOG_INFO(">>> EOS_Presence_CopyPresence: peer product='%s' v='%s', join_info='%s', %d record(s)",
+                 info->ProductId, info->ProductVersion, pf->join_info, n);
+    for (int i = 0; i < n; i++) {
+        EOS_LOG_INFO(">>>   presence record[%d]: '%s' = '%s'", i, blk->recs[i].Key, blk->recs[i].Value);
+    }
     return EOS_Success;
 }
 


### PR DESCRIPTION
Mainline the generic LAN-emu fixes that enable native friends-list browse→join for EOSPlus+Steam titles (validated end-to-end on StarRupture: friend appears in Join Game → join → `Welcomed by server` → travel into host world).

Cherry-picked off `diag/session-config-logging` with **all diagnostic-only logging commits stripped**:
- `connect: map Steam external id → peer's real Epic handle in EpicAccountId_FromString` — the load-bearing fix (UE friend-search is epic-keyed)
- `presence: auto-derive local presence from a presence-enabled lobby` (+ release announce-hold, real product identity, `MAX_PRESENCE_RECORDS` 8→24)
- `social: map Steam external accounts to PUIDs over the LAN beacon`
- `auth: EpicAccountId_FromString returns NULL for malformed ids` (crash-fix)
- `lobby_search` / `session_search` owner-match; immediate session propagation

Builds clean on CI (verified the bridge + presence-from-lobby symbols are present in the artifact).